### PR TITLE
NullPointerException in RoutingTableImpl.

### DIFF
--- a/src/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
+++ b/src/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
@@ -418,9 +418,12 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
 		                // This is a route to a local component hosted in this node (route
 		                // could have been added after our previous check)
 		                try {
-		                    localRoutingTable.getRoute(jid.getDomain()).process(packet);
-		                    routed = true;
-		                    break;
+		                    RoutableChannelHandler localRoute = localRoutingTable.getRoute(jid.getDomain());
+		                    if (localRoute != null) {
+		                        localRoute.process(packet);
+		                        routed = true;
+		                        break;
+		                    }
 		                } catch (UnauthorizedException e) {
 		                    Log.error("Unable to route packet " + packet.toXML(), e);
 		                }


### PR DESCRIPTION
In #routeToComponent, it is first checked if the component is being hosted in the local JVM. If it was not found, then all nodes in the ComponentsCache are checked to find if the component is hosted by one of those. In this process, the local routing table is again searched for the component, because it may have been added after the previous check. However, after this search, there is no null check done for the searched route. This results in an NPE when the component was not found locally and the #process(packet) method is called on the object. 

This also prevents the code from searching other nodes that may have been in the nodes set. Added a null check to prevent this scenario.
